### PR TITLE
feat: フラッシュメッセージ表示機能の追加

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,6 @@
 class StaticPagesController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
+
   def top
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,8 +6,9 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to root_path
+      redirect_back_or_to root_path, notice: (t '.success')
     else
+      flash.now[:notice] = (t '.fail')
       render :new
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,8 +8,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to login_path
+      redirect_to login_path, notice: (t '.success')
     else
+      flash.now[:notice] = (t '.fail')
       render :new
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
+    <%= render 'shared/flash_message' %>
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,3 @@
+<% flash.each do |message_type, message| %>
+  <div class="notice"><%= message %></div>
+<% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,11 +7,19 @@ ja:
     new:
       title: 'サインアップ'
       to_login_page: 'ログインはこちら→'
+    create:
+      success: 'ユーザー登録が完了しました'
+      fail: 'ユーザー登録に失敗しました'
   user_sessions:
     new:
       title: 'ログイン'
       to_register_page: 'サインアップはこちら→'
       password_forget: 'パスワードをお忘れの方はこちら→'
+    create:
+      success: 'ログインしました'
+      fail: 'ログインに失敗しました'
+    destroy:
+      success: 'ログアウトしました'
   contents:
     index:
       title: 'これまでに記録した建築一覧'


### PR DESCRIPTION
フラッシュメッセージ表示機能を追加しました。

## チェック項目
- [x] ログイン成功時に「ログインしました」と表示される
- [x] ログイン失敗時に「ログインに失敗しました」と表示される
- [x] ユーザー登録完了時に「ユーザー登録が完了しました」と表示される
- [x] ユーザー登録失敗時に「ユーザ登録に失敗しました」と表示される