### PR TITLE
feat: 建築編集・削除機能の追加

### DIFF
--- a/app/controllers/architecture_controller.rb
+++ b/app/controllers/architecture_controller.rb
@@ -21,6 +21,26 @@ class ArchitectureController < ApplicationController
     @architecture = Architecture.find(params[:id])
   end
 
+  def edit
+    @architecture = current_user.architecture.find(params[:id])
+  end
+
+  def update
+    @architecture = current_user.architecture.find(params[:id])
+    if @architecture.update(architecture_params)
+      redirect_to @architecture, notice: t('defaults.message.updated', item: Architecture.model_name.human)
+    else
+      flash.now['notice'] = t('defaults.message.not_updated', item: Architecture.model_name.human)
+      render :edit
+    end
+  end
+
+  def destroy
+    @architecture = current_user.architecture.find(params[:id])
+    @architecture.destroy!
+    redirect_to architecture_index_path, notice: t('defaults.message.deleted', item: Architecture.model_name.human)
+  end
+
   private
 
   def architecture_params

--- a/app/javascript/packs/architecture/render.js
+++ b/app/javascript/packs/architecture/render.js
@@ -1,1 +1,1 @@
-history.replaceState('', '', '/architecture/new')
+// history.replaceState('', '', '/architecture/new')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,8 @@ class User < ApplicationRecord
 
   validates :email, uniqueness: true, presence: true
   validates :name, presence: true, length: { maximum: 255 }
+
+  def own?(object)
+    id == object.user_id
+  end
 end

--- a/app/views/architecture/_architecture.html.erb
+++ b/app/views/architecture/_architecture.html.erb
@@ -13,7 +13,7 @@
       </a>
     </h4>
     <p><%= architecture.description %></p>
-    <%= render 'crud_menus', architecture: architecture %>
+    <%= render 'crud_menus', architecture: architecture if current_user.own?(architecture) %>
     <ul>
       <li>
         <%= icon 'far', 'user' %>

--- a/app/views/architecture/_crud_menus.html.erb
+++ b/app/views/architecture/_crud_menus.html.erb
@@ -1,11 +1,11 @@
 <ul>
   <li>
-    <%= link_to '#' do %>
+    <%= link_to edit_architecture_path(architecture), id: "button-edit-#{architecture.id}" do %>
       <%= icon 'fa', 'pen', style: 'color: #ee5858' %>
     <% end %>
   </li>
   <li>
-    <%= link_to '#' do %>
+    <%= link_to architecture_path(architecture), id: "button-delete-#{architecture.id}", method: :delete, data: { confirm: t('defaults.message.delete_confirm') } do %>
       <%= icon 'fas', 'trash', style: 'color: #ee5858' %>
     <% end %>
   </li>

--- a/app/views/architecture/edit.html.erb
+++ b/app/views/architecture/edit.html.erb
@@ -1,0 +1,9 @@
+<% content_for(:title, @architecture.name) %>
+<h2><%= t('.title', architecture_name: @architecture.name) %></h2>
+<div>
+  <div>
+    <div>
+      <%= render 'form', { architecture: @architecture } %>
+    </div>
+  </div>
+</div>

--- a/app/views/architecture/show.html.erb
+++ b/app/views/architecture/show.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:title, @architecture.name) %>
-<h1><%= t('.title', architecture_name: @architecture.name) %></h1>
-<article class="card">
-  <div class="card-body">
-    <div class='row'>
-      <div class='col-md-3'>
+<h2><%= t('.title', architecture_name: @architecture.name) %></h2>
+<article>
+  <div>
+    <div>
+      <div>
         <% if @architecture.images.any? %>
           <% @architecture.images.each do |image| %>
             <%= image_tag image.url, size: '300x200' %>
@@ -12,12 +12,11 @@
           <%= image_tag 'architecture_placeholder.png' %>
         <% end %>
       </div>
-      <div class='col-md-9'>
-        <h3 class="d-inline"><%= t('.title', architecture_name: @architecture.name) %></h3>
-        <%= render 'crud_menus', architecure: @architecture %>
-        <ul class="list-inline">
-          <li class="list-inline-item">by <%= @architecture.user.name %></li>
-          <li class="list-inline-item"><%= l @architecture.created_at, format: :long  %></li>
+      <div>
+        <%= render 'crud_menus', architecture: @architecture if current_user.own?(@architecture) %>
+        <ul>
+          <li>by <%= @architecture.user.name %></li>
+          <li><%= l @architecture.created_at, format: :long  %></li>
         </ul>
       </div>
     </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,6 +7,10 @@ ja:
       require_login: 'ログインしてください'
       created: "%{item}を記録しました"
       not_created: "%{item}の記録に失敗しました"
+      updated: "%{item}を更新しました"
+      not_updated: "%{item}を更新できませんでした"
+      deleted: "%{item}を削除しました"
+      delete_confirm: '削除しますか？'
   static_pages:
     top:
       record: '訪れた建築を記録する✍️'
@@ -36,8 +40,10 @@ ja:
       title: '訪れた建築を記録しよう✍️'
     show:
       title: '%{architecture_name}'
+    edit:
+      title: '建築の詳細を編集✍️'
     likes:
-      title: 'Like一覧'
+      title: 'Like一覧❤️'
   profiles:
     show:
       title: 'プロフィール'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
-  resources :architecture, only: %i[index new create show]
+  resources :architecture
 end


### PR DESCRIPTION
## チェック項目
### 画面遷移
- [x] 建築詳細画面から建築編集画面に遷移できる
- [x] 編集が完了したら建築詳細ページに遷移する
- [x] 建築一覧ページ、建築詳細ページから削除できる
- [x] 削除が完了したら建築一覧ページに遷移する
- [x] 他人の記録した建築の編集ページにアクセスした場合404エラーが発生する

### その他
- [x] 自分が記録した建築詳細画面にのみ編集ボタンが表示される
- [x] 編集が完了したら「更新しました」というフラッシュメッセージが表示される
- [x] 削除ボタン押下時にはアラートが表示される