### PR TITLE
feat: プロフィール機能を追加

### DIFF
--- a/app/controllers/architecture_controller.rb
+++ b/app/controllers/architecture_controller.rb
@@ -44,7 +44,7 @@ class ArchitectureController < ApplicationController
 
   def random
     user_liked_architecture_ids = Like.where(user_id: current_user.id).pluck(:architecture_id)
-    architecture = Architecture.where.not(id: user_liked_architecture_ids)
+    architecture = Architecture.where.not(id: user_liked_architecture_ids).where(open_range: 'publish')
     @architecture = architecture.not_by(current_user).offset( rand(architecture.not_by(current_user).count) ).first
   end
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -7,9 +7,9 @@ class ProfilesController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to profile_path, success: t('defaults.message.updated', item: User.model_name.human)
+      redirect_to profile_path, notice: t('defaults.message.updated', item: User.model_name.human)
     else
-      flash.now['danger'] = t('defaults.message.not_updated', item: User.model_name.human)
+      flash.now['notice'] = t('defaults.message.not_updated', item: User.model_name.human)
       render :edit
     end
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,32 @@
+class ProfilesController < ApplicationController
+  before_action :set_user, only: %i[edit update]
+
+  def show; end
+  
+  def edit; end
+
+  def update
+    if @user.update(user_params)
+      redirect_to profile_path, success: t('defaults.message.updated', item: User.model_name.human)
+    else
+      flash.now['danger'] = t('defaults.message.not_updated', item: User.model_name.human)
+      render :edit
+    end
+  end
+
+  def destroy
+    user = User.find(current_user.id)
+    user.destroy!
+    redirect_to login_path, notice: t('defaults.message.deleted', item: User.model_name.human)
+  end
+
+  private
+
+  def set_user
+    @user = User.find(current_user.id)
+  end
+
+  def user_params
+    params.require(:user).permit(:email, :last_name, :first_name, :avatar, :avatar_cache)
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -27,6 +27,6 @@ class ProfilesController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:email, :last_name, :first_name, :avatar, :avatar_cache)
+    params.require(:user).permit(:email, :name, :avatar, :avatar_cache)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  mount_uploader :avatar, AvatarUploader
+
   has_many :architecture, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :like_architecture, through: :likes, source: :architecture

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,0 +1,16 @@
+class AvatarUploader < CarrierWave::Uploader::Base
+  storage :file
+
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  def default_url
+    'sample.jpg'
+  end
+
+  def extension_whitelist
+    %i[jpg jpeg gif png]
+  end
+
+end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,26 @@
+<% content_for(:title, t('.title')) %>
+<div>
+  <h2><%= t('.title') %></h2>
+  <%= form_with model: @user, url: profile_path, local: true do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
+    <%= f.label :email %>
+    <%= f.email_field :email %>
+
+    <%= f.label :name %>
+    <%= f.text_field :name %>
+
+    <%= f.label :avatar %>
+    <%= f.file_field :avatar, onchange: 'previewFileWithId(preview)', accept: 'image/*' %>
+    <%= f.hidden_field :avatar_cache %>
+
+    <div>
+      <%= image_tag @user.avatar.url,
+                    id: 'preview',
+                    size: '200x200' %>
+    </div>
+
+    <%= link_to t('defaults.delete'), profile_path, method: :delete, data: { confirm: t('defaults.message.user_delete_confirm') } %>
+
+    <%= f.submit %>
+  <% end %>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,19 @@
+<% content_for(:title, t('.title')) %>
+<div>
+  <h1><%= t('.title') %></h1>
+  <%= link_to t('defaults.edit'), edit_profile_path %>
+  <table>
+    <tr>
+      <th scope="row"><%= t(User.human_attribute_name(:email)) %></th>
+      <td><%= current_user.email %></td>
+    </tr>
+    <tr>
+      <th scope="row"><%= t(User.human_attribute_name(:name)) %></th>
+      <td><%= current_user.name %></td>
+    </tr>
+    <tr>
+      <th scope="row"><%= t(User.human_attribute_name(:avatar)) %></th>
+      <td><%= image_tag current_user.avatar.url, size: '200x200' %></td>
+    </tr>
+  </table>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,8 +1,12 @@
 <% content_for(:title, t('.title')) %>
 <div>
-  <h1><%= t('.title') %></h1>
+  <h2><%= t('.title') %></h2>
   <%= link_to t('defaults.edit'), edit_profile_path %>
   <table>
+    <tr>
+      <th scope="row"><%= t('.recorded_architecture_count') %></th>
+      <td><%= current_user.architecture.count %></td>
+    </tr>
     <tr>
       <th scope="row"><%= t(User.human_attribute_name(:email)) %></th>
       <td><%= current_user.email %></td>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,10 +21,10 @@
           <%= link_to new_architecture_path, class: 'icon' do %>
             <i class="fa-solid fa-pen fa-2x" style="color: #ee5858;"></i>
           <% end %>
-          <%= link_to '#', class: 'icon' do %>
+          <%= link_to profile_path, class: 'icon' do %>
             <i class="fa-sharp fa-solid fa-user fa-2x" style="color: #ee5858;"></i>
           <% end %>
-          <%= link_to logout_path, class: 'icon', method: :delete do %>
+          <%= link_to logout_path, class: 'icon', method: :delete, data: { confirm: t('defaults.message.logout_confirm') } do %>
             <i class="fa-solid fa-arrow-right-from-bracket fa-2x" style="color: #ee5858;"></i>
           <% end %>
         </li>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -9,7 +9,7 @@ ja:
         email: 'メールアドレス'
         password: 'パスワード'
         password_confirmation: 'パスワード確認'
-        avatar: 'アバター'
+        avatar: 'プロフィール画像'
       architecture:
         name: '建築名'
         location: '所在地'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -9,6 +9,7 @@ ja:
         email: 'メールアドレス'
         password: 'パスワード'
         password_confirmation: 'パスワード確認'
+        avatar: 'アバター'
       architecture:
         name: '建築名'
         location: '所在地'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -4,6 +4,8 @@ ja:
     sign_up: 'サインアップ'
     logout: 'ログアウト'
     search_word: '建築名を入力'
+    edit: '編集'
+    delete: '退会する'
     message:
       require_login: 'ログインしてください'
       created: "%{item}を記録しました"
@@ -12,6 +14,8 @@ ja:
       not_updated: "%{item}を更新できませんでした"
       deleted: "%{item}を削除しました"
       delete_confirm: '削除しますか？'
+      logout_confirm: 'ログアウトしますか？'
+      user_delete_confirm: '退会しますか？'
   static_pages:
     top:
       record: '訪れた建築を記録する✍️'
@@ -57,3 +61,5 @@ ja:
   profiles:
     show:
       title: 'プロフィール'
+    edit:
+      title: 'プロフィールを編集✍️'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -60,6 +60,7 @@ ja:
       success: 'Unlike💔'
   profiles:
     show:
-      title: 'プロフィール'
+      title: 'プロフィール👀'
+      recorded_architecture_count: '記録した建築総数は、、、'
     edit:
       title: 'プロフィールを編集✍️'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,5 @@ Rails.application.routes.draw do
     end
   end
   resources :likes, only: %i[create destroy]
+  resource :profile, only: %i[show edit update destroy]
 end

--- a/db/migrate/20230429161430_add_avatar_to_users.rb
+++ b/db/migrate/20230429161430_add_avatar_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :avatar, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_29_055739) do
+ActiveRecord::Schema.define(version: 2023_04_29_161430) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2023_04_29_055739) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "avatar"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
## チェック項目
### 表示
- [x] プロフィール詳細 / 編集画面では以下の項目が表示される。
- これまでに記録した建築総数
- ユーザーネーム
- メールアドレス
- プロフィール画像

### 画面遷移
- [x] メニューバーからプロフィール編集画面に遷移できる
- [x] ユーザー情報の更新に成功すると、ユーザー詳細ページに遷移する

### フラッシュメッセージ
- [x] 編集成功時に「ユーザーを更新しました」と表示される
- [x] 編集失敗時に「ユーザーを更新できませんでした」と表示される

### その他
- [x] 「プロフィール画像」をクリックすると、画像ファイルの選択ができる