### PR TITLE
fix: 建築一覧ページのビューを変更

### DIFF
--- a/app/views/architecture/_architecture.html.erb
+++ b/app/views/architecture/_architecture.html.erb
@@ -1,22 +1,11 @@
-<div>
-  <% if architecture.images.any? %>
-    <% architecture.images.each do |image| %>
-      <%= image_tag image.url, size: '300x200' %>
-    <% end %>
-  <% else %>
-    <%= image_tag 'architecture_placeholder.png' %>
+<div class="group relative flex h-80 items-end overflow-hidden rounded-md bg-gray-100 p-4 shadow-lg">
+  <%= link_to architecture_path(architecture) do %>
+    <%= image_tag architecture.images.first.url, class: 'absolute inset-0 h-full w-full object-cover object-center transition duration-200 group-hover:scale-110'%>
   <% end %>
-  <div>
-    <h4>
-      <a href="#" style="color: black;">
-        <%= link_to architecture.name, architecture_path(architecture) %>
-      </a>
-    </h4>
-    <p><%= architecture.description %></p>
-    <% if current_user.own?(architecture) %>
-      <%= render 'crud_menus', architecture: architecture %>
-    <% else %>
-      <%= render 'like_button', architecture: architecture %>
-    <% end %>
+  <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-gray-900 via-transparent to-transparent opacity-50"></div>
+
+  <div class="relative flex flex-col">
+    <span class="text-gray-300"><%= architecture.location %></span>
+    <span class="text-lg text-white lg:text-xl"><%= architecture.name %></span>
   </div>
 </div>

--- a/app/views/architecture/_crud_menus.html.erb
+++ b/app/views/architecture/_crud_menus.html.erb
@@ -1,12 +1,12 @@
-<ul>
+<ul class="flex">
   <li>
-    <%= link_to edit_architecture_path(architecture), id: "button-edit-#{architecture.id}" do %>
-      <%= icon 'fa', 'pen', style: 'color: #ee5858' %>
+    <%= link_to architecture_path(architecture), method: :delete, data: { confirm: t('defaults.message.delete_confirm') } do %>
+      <i class="fa-regular fa-trash-can text-third"></i>
     <% end %>
   </li>
   <li>
-    <%= link_to architecture_path(architecture), id: "button-delete-#{architecture.id}", method: :delete, data: { confirm: t('defaults.message.delete_confirm') } do %>
-      <%= icon 'fas', 'trash', style: 'color: #ee5858' %>
+    <%= link_to edit_architecture_path(architecture) do %>
+      <i class="fa-regular fa-pen-to-square ml-2 text-third"></i>
     <% end %>
   </li>
 </ul>

--- a/app/views/architecture/_form.html.erb
+++ b/app/views/architecture/_form.html.erb
@@ -4,7 +4,7 @@
       <%= render 'shared/error_messages', object: f.object %>
       <div class="mb-12">
         <%= f.label :name, class: 'block text-black mb-2' %>
-        <%= f.text_field :name, class: 'form-input block w-full py-1 border border-gray-400 rounded-full transition duration-200 focus:border-transparent focus:ring-third focus:ring-offset-2 focus:ring-offset-gray-500', required: true %>
+        <%= f.text_field :name, class: 'form-input block w-full py-1 border border-gray-400 rounded-full transition duration-200 focus:border-transparent focus:ring-third focus:ring-offset-2 focus:ring-offset-gray-500', placeholder: (t 'defaults.National Museum of Western Art'), required: true %>
       </div>
       <div class="mb-12">
         <%= f.label :location, class: 'block text-black mb-2' %>
@@ -17,7 +17,7 @@
       </div>
       <div class="mb-12">
         <%= f.label :architect, class: 'block text-black mb-2' %>
-        <%= f.text_field :architect, class: 'form-input block w-full py-1 border border-gray-400 rounded-full transition duration-200 focus:border-transparent focus:ring-third focus:ring-offset-2 focus:ring-offset-gray-500' %>
+        <%= f.text_field :architect, class: 'form-input block w-full py-1 border border-gray-400 rounded-full transition duration-200 focus:border-transparent focus:ring-third focus:ring-offset-2 focus:ring-offset-gray-500', placeholder: (t 'defaults.Le Corbusier') %>
       </div>
       <div class="mb-12">
         <%= f.label :description, class: 'block text-black mb-2' %>

--- a/app/views/architecture/_search_form.html.erb
+++ b/app/views/architecture/_search_form.html.erb
@@ -1,8 +1,10 @@
 <%= search_form_for @q, url: url do |f| %>
-  <div>
-    <%= f.search_field :name_cont, placeholder: t('defaults.search_word') %>
-    <div>
-      <%= f.submit %>
-    </div>
+  <div class="flex justify-center sm:justify-end items-center text-xs mb-12">
+    <form class="flex">
+      <%= f.search_field :name_cont, placeholder: 'Search', class: 'w-60 px-4 py-0 rounded-full focus:border-transparent focus:ring-2 focus:ring-second' %>
+      <div class="ml-2 px-4 py-1 bg-second text-black text-sm rounded-full hover:scale-110 hover:shadow-lg">
+        <%= f.submit 'Search' %>
+      </div>
+    </form>
   </div>
 <% end %>

--- a/app/views/architecture/index.html.erb
+++ b/app/views/architecture/index.html.erb
@@ -1,16 +1,17 @@
 <% content_for(:title, t('.title')) %>
-<h2><%= t('.title', architecture_name: @architecture.name) %></h2>
-<div>
-  <!-- 検索フォーム -->
-  <%= render 'search_form', url: architecture_index_path %> 
-   <!-- 建築一覧 -->
-  <div>
-    <% if @architecture.present? %>
-      <%= render @architecture %>
-    <% else %>
-      <p><%= t('.no_result') %></p>
-    <% end %>
+<div class="bg-white py-6 sm:py-8 lg:py-12">
+  <div class="mx-auto max-w-screen-2xl px-4 md:px-8">
+    <%= render 'search_form', url: architecture_index_path %>
+    <div class="m-10 md:m-16">
+      <h2 class="text-center text-xl"><%= t('.title') %></h2>
+    </div>
+    <div class="grid gap-6 sm:grid-cols-2">
+      <% if @architecture.present? %>
+        <%= render @architecture %>
+      <% else %>
+        <p><%= t('.no_result') %></p>
+      <% end %>
+    </div>
+    <%= paginate @architecture %>
   </div>
-  <!-- ページネーション -->
-  <%= paginate @architecture %>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <header class="py-1">
   <div class="container mx-auto flex justify-between items-center px-4 md:px-8 lg:px-12 w-full text-theme">
-    <%= link_to "archimate", root_path, class: "text-xl mr-12" %>
+    <%= link_to 'archimate', root_path, class: 'text-xl mr-12' %>
     <% if logged_in? %>
       <div class="space-x-12 hidden lg:flex items-center text-sm">
         <%= link_to (t 'architecture.new.title'), new_architecture_path %>
@@ -16,21 +16,27 @@
       </div>
     <% end %>
     <div class="lg:hidden">
-      <nav>
-        <button id="button" type="button" class="fixed z-20 top-1 right-6">
-          <i id="bars" class="fa-solid fa-bars text-2xl"></i>
-          <i id="xmark" class="hidden fa-solid fa-x text-2xl"></i>
-        </button>
-        <ul id="menu" class="fixed top-0 left-0 z-10 w-full translate-x-full text-sm bg-third text-center transition duration-300 ease-linear">
-          <li class="p-3"><%= link_to (t 'header.top'), root_path %></li>
-          <li class="p-3"><%= link_to (t 'architecture.new.title'), new_architecture_path %></li>
-          <li class="p-3"><%= link_to (t 'architecture.index.title'), architecture_index_path %></li>
-          <li class="p-3"><%= link_to (t 'architecture.likes.title'), likes_architecture_index_path %></li>
-          <li class="p-3"><%= link_to (t 'header.detailed_search'), architecture_index_path %></li>
-          <li class="p-3"><%= link_to (t 'profiles.show.title'), profile_path %></li>
-          <li class="p-3"><%= link_to (t 'defaults.logout'), logout_path, method: :delete, data: { confirm: t('defaults.message.logout_confirm') } %></li>
-        </ul>
-      </nav>
+      <% if logged_in? %>
+        <nav>
+          <button id="button" type="button" class="fixed z-20 top-1 right-6">
+            <i id="bars" class="fa-solid fa-bars text-2xl"></i>
+            <i id="xmark" class="hidden fa-solid fa-x text-2xl"></i>
+          </button>
+          <ul id="menu" class="fixed top-0 left-0 z-10 w-full translate-x-full text-sm bg-third text-center transition duration-300 ease-linear">
+            <li class="p-3"><%= link_to (t 'header.top'), root_path %></li>
+            <li class="p-3"><%= link_to (t 'architecture.new.title'), new_architecture_path %></li>
+            <li class="p-3"><%= link_to (t 'architecture.index.title'), architecture_index_path %></li>
+            <li class="p-3"><%= link_to (t 'architecture.likes.title'), likes_architecture_index_path %></li>
+            <li class="p-3"><%= link_to (t 'header.detailed_search'), architecture_index_path %></li>
+            <li class="p-3"><%= link_to (t 'profiles.show.title'), profile_path %></li>
+            <li class="p-3"><%= link_to (t 'defaults.logout'), logout_path, method: :delete, data: { confirm: t('defaults.message.logout_confirm') } %></li>
+          </ul>
+        </nav>
+      <% else %>
+      <div>
+        <%= link_to (t 'defaults.login'), login_path %>
+      </div>
+    <% end %>
     </div>
   </div>
 </header>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 2
+  config.default_per_page = 10
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -3,13 +3,14 @@ ja:
     login: 'ログイン'
     sign_up: 'サインアップ'
     logout: 'ログアウト'
-    search_word: '建築名を入力'
     edit: '編集'
     delete: '退会する'
     password_reset: 'パスワードリセット'
     Or continue with: '又は'
     record: '記録'
+    National Museum of Western Art: '例 : 国立西洋美術館'
     Taito-ku, Tokyo-to 110-0007 Japan: '例 : 東京都台東区上野公園7-7-7'
+    Le Corbusier: '例 : ル・コルビュジエ'
     message:
       require_login: 'ログインしてください'
       created: "%{item}を記録しました"
@@ -51,7 +52,7 @@ ja:
       success: 'ログアウトしました'
   architecture:
     index:
-      title: '訪れた建築一覧'
+      title: '訪れた建築'
       no_result: '記録した建築がありません'
     new:
       title: '建築を記録'
@@ -60,7 +61,7 @@ ja:
     edit:
       title: '建築を編集'
     likes:
-      title: 'Like一覧'
+      title: 'Likeした建築'
       no_result: 'Likeした建築がありません..'
   likes:
     create:
@@ -69,7 +70,7 @@ ja:
       success: 'Unlike'
   profiles:
     show:
-      title: 'プロフィール'
+      title: 'ログ'
       recorded_architecture_count: '記録した建築総数は、、、'
     edit:
       title: 'プロフィールを編集✍️'


### PR DESCRIPTION
## チェック項目
- [x] 建築一覧表示のビューにtailwindcssが当たっている
- [x] 検索フォームにtailwindcssが当たっている
- [x] 各建築写真をクリックするとその建築の詳細画面に遷移する

### その他の変更
- [x] 未ログイン状態で画面幅がlg以下の時に、ハンバーガーメニューではなくログイン画面へのリンクが表示されている
- [x] 建築新規記録フォームのビューに記入例のplace_holderが表示されている