### PR TITLE
fix: 建築詳細ページのビューを変更

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -6,8 +6,8 @@ class LikesController < ApplicationController
   end
 
   def destroy
-    architecture = current_user.likes.find(params[:id]).architecture
+    architecture = current_user.likes.find_by(architecture_id: params[:id]).architecture
     current_user.unlike(architecture)
-    redirect_back fallback_location: root_path, success: t('.success')
+    redirect_to likes_architecture_index_path, success: t('.success')
   end
 end

--- a/app/models/architecture.rb
+++ b/app/models/architecture.rb
@@ -17,4 +17,8 @@ class Architecture < ApplicationRecord
   def self.not_by(user)
     self.where.not(user_id: user.id)
   end
+
+  def by?(user)
+    self.user_id == user.id
+  end
 end

--- a/app/views/architecture/_form.html.erb
+++ b/app/views/architecture/_form.html.erb
@@ -25,7 +25,11 @@
       </div>
       <div class="mb-20">
         <%= f.label :images, class: 'block text-black mb-2' %>
-        <%= f.file_field :images, multiple: true, accept: 'image/*', class: 'form-input block w-full py-1 border border-gray-400 rounded-full transition duration-200 focus:border-transparent focus:ring-third focus:ring-offset-2 focus:ring-offset-gray-500', required: true %>
+        <div id="image-preview-container">
+          <div class="mb-4">
+            <%= f.file_field :images, accept: 'image/*', class: 'form-input block w-full py-1 border border-gray-400 rounded-full transition duration-200 focus:border-transparent focus:ring-third focus:ring-offset-2 focus:ring-offset-gray-500', multiple: true, onchange: 'showPreview(event)' %>
+          </div>
+        </div>
         <%= f.hidden_field :images_cache %>
       </div>
       <div class="flex justify-center">
@@ -34,3 +38,45 @@
     <% end %>
   </div>
 </div>
+
+<!-- turbolinksの無効化 -->
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    // turbolinksを無効化するための設定
+    var turbolinksEnabled = <%= Rails.configuration.action_view.form_with_generates_remote_forms %>;
+
+    if (turbolinksEnabled) {
+      document.querySelector('form').addEventListener('submit', function(event) {
+        event.preventDefault();
+        Turbolinks.visit(event.target.action + '?' + new URLSearchParams(new FormData(event.target)).toString());
+      });
+    }
+  });
+</script>
+
+<script>
+  // 画像ファイルのプレビューを表示する関数
+  function showPreview(event) {
+    const previewContainer = document.getElementById('image-preview-container');
+
+    const files = Array.from(event.target.files); // 選択されたファイルを配列に保存
+
+    files.forEach((file) => {
+      const reader = new FileReader();
+
+      reader.onload = function(e) {
+        const previewDiv = document.createElement('div');
+        previewDiv.classList.add('mb-4');
+
+        const image = document.createElement('img');
+        image.src = e.target.result;
+        image.classList.add('block', 'object-cover', 'rounded-md', 'mr-2');
+
+        previewDiv.appendChild(image);
+        previewContainer.appendChild(previewDiv);
+      };
+
+      reader.readAsDataURL(file); // ファイルの内容を読み込む
+    });
+  }
+</script>

--- a/app/views/architecture/likes.html.erb
+++ b/app/views/architecture/likes.html.erb
@@ -1,20 +1,17 @@
 <% content_for(:title, t('.title')) %>
-<h2><%= t('.title', architecture_name: @like_architecture.name) %></h2>
-<div>
-  <div>
-    <div>
-      <!-- 検索フォーム -->
-      <%= render 'search_form', url: likes_architecture_index_path %>
+<div class="bg-white py-6 sm:py-8 lg:py-12">
+  <div class="mx-auto max-w-screen-2xl px-4 md:px-8">
+    <%= render 'search_form', url: @like_architecture_index_path %>
+    <div class="m-10 md:m-16">
+      <h2 class="text-center text-xl"><%= t('.title') %></h2>
     </div>
+    <div class="grid gap-6 sm:grid-cols-2">
+      <% if @like_architecture.present? %>
+        <%= render @like_architecture %>
+      <% else %>
+        <p><%= t('.no_result') %></p>
+      <% end %>
+    </div>
+    <%= paginate @like_architecture %>
   </div>
-  <!-- 建築一覧 -->
-  <div>
-    <% if @like_architecture.present? %>
-      <%= render @like_architecture %>
-    <% else %>
-      <p><%= t('.no_result') %></p>
-    <% end %>
-  </div>
-  <!-- ページネーション -->
-  <%= paginate @like_architecture %>
 </div>

--- a/app/views/architecture/show.html.erb
+++ b/app/views/architecture/show.html.erb
@@ -1,25 +1,111 @@
-<% content_for(:title, @architecture.name) %>
-<h2><%= t('.title', architecture_name: @architecture.name) %></h2>
-<article>
-  <div>
-    <div>
-      <div>
-        <% if @architecture.images.any? %>
-          <% @architecture.images.each do |image| %>
-            <%= image_tag image.url, size: '300x200' %>
-          <% end %>
-        <% else %>
-          <%= image_tag 'architecture_placeholder.png' %>
-        <% end %>
+<% if @architecture.present? %>
+  <div class="flex flex-col md:flex-row items-end">
+    <div class="w-full md:w-3/4 h-96 md:h-screen relative">
+      <% if @architecture.images.any? %>
+        <%= image_tag @architecture.images.first.url, class: 'image absolute inset-0 object-cover object-top h-full w-full' %>
+      <% else %>
+        <%= image_tag 'architecture_placeholder.png', class: 'absolute inset-0 object-cover object-top h-full w-full' %>
+      <% end %>
+      <div class="progress-bar h-1 bg-second absolute top-0 left-0 ease-in-out duration-300"></div>
+      <div class="description hidden absolute inset-0 bg-black bg-opacity-50 text-white p-4 tracking-widest">
+        <button class="close-btn absolute top-2 right-2 p-2 text-xl text-white">
+          <span class="fa-stack hover:scale-110">
+            <i class="fas fa-circle fa-stack-2x text-white fa-stack-2x"></i>
+            <i class="fa-solid fa-xmark text-theme text-2xl fa-stack-1x pt-1"></i>
+          </span>
+        </button>
+        <div class="flex flex-col justify-center items-center h-full">
+          <div class="max-w-2xl sm:mt-12 mt-6">
+            <p><%= safe_join(@architecture.description.split("\n"), tag(:br)) %></p>
+            <br>
+            <% if @architecture.architect.present? %>
+              <p><%= Architecture.human_attribute_name(:architect) %> : <%= @architecture.architect %></p>
+            <% end %>
+          </div>
+        </div>
       </div>
-      <p><%= simple_format(@architecture.description) %></p>
-      <div>
-        <% if current_user.own?(@architecture) %>
-          <%= render 'crud_menus', architecture: @architecture %>
-        <% else %>
-          <%= render 'like_button', architecture: @architecture %>
-        <% end %>
+      <button class="toggle-btn absolute top-0 right-0 p-4 text-xl">
+        <span class="fa-stack hover:scale-110">
+          <i class="fas fa-circle fa-stack-2x text-white fa-stack-2x"></i>
+          <i class="fa-solid fa-book-open-reader text-theme text-2xl fa-stack-1x pt-1"></i>
+        </span>
+      </button>
+    </div>
+    <div class="w-full md:w-144 px-4 md:pt-0 pt-4">
+      <h1 class="text-3xl md:text-5xl mb-4"><%= @architecture.name %></h1>
+      <div class="relative my-8 mb-20">
+        <p><%= simple_format(@architecture.location) %></p>
+        <div class="flex items-center pt-2">
+          <i class="fa-sharp fa-solid fa-location-dot"></i>
+          <p class="px-2">距離 28km</p>
+        </div>
+        <div class="pt-4">
+          <% if @architecture.by?(current_user) %>
+            <%= button_to 'Edit', edit_architecture_path(@architecture), method: :get, class: 'w-full bg-sixth text-black mb-4 rounded-full hover:scale-105 hover:drop-shadow-lg' %>
+            <%= button_to 'Destroy', architecture_path(@architecture), method: :delete, data: { confirm: t('defaults.message.destroy_confirm') }, class: 'w-full bg-seventh text-white rounded-full mt-4 hover:scale-105 hover:drop-shadow-lg' %>
+          <% elsif current_user.like?(@architecture) %>
+            <%= button_to 'Check in', new_architecture_path, method: :get, class: 'w-full bg-second text-black mb-4 rounded-full hover:scale-105 hover:drop-shadow-lg' %>
+            <%= button_to 'Not Like', like_path, method: :delete, class: 'w-full bg-seventh text-white rounded-full mt-4 hover:scale-105 hover:drop-shadow-lg' %>
+          <% else %>
+            <%= button_to 'Like', likes_path(architecture_id: @architecture.id), method: :post, class: 'w-full bg-second text-black mb-4 rounded-full hover:scale-105 hover:drop-shadow-lg' %>
+            <%= button_to 'Reload', root_path, method: :get, class: 'w-full bg-black text-white rounded-full mt-4 hover:scale-105 hover:drop-shadow-lg' %>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>
-</article>
+<% else %>
+  <p><%= t('.no_result') %></p>
+<% end %>
+
+<script>
+  document.addEventListener("turbolinks:load", function() {
+    initializeArchitecture();
+  });
+
+  function initializeArchitecture() {
+    const images = <%= @architecture.images.to_json.html_safe %>;
+    const image = document.querySelector(".image");
+    const progressBar = document.querySelector(".progress-bar");
+    const toggleBtn = document.querySelector(".toggle-btn");
+    const description = document.querySelector(".description");
+    const closeBtn = document.querySelector(".close-btn");
+    let currentIndex = 0;
+
+    updateProgressBar();
+
+    image.addEventListener("click", function(event) {
+      const clickedX = event.clientX - event.target.getBoundingClientRect().left;
+      const halfWidth = event.target.clientWidth / 2;
+
+      if (clickedX >= halfWidth) {
+        currentIndex = (currentIndex + 1) % images.length;
+      } else {
+        currentIndex = (currentIndex - 1 + images.length) % images.length;
+      }
+
+      image.src = images[currentIndex].url;
+      updateProgressBar();
+      hideDescription();
+    });
+
+    toggleBtn.addEventListener("click", toggleDescription);
+
+    closeBtn.addEventListener("click", hideDescription);
+
+    function updateProgressBar() {
+      const progressBarWidth = (currentIndex + 1) * (100 / images.length);
+      progressBar.style.width = `${progressBarWidth}%`;
+    }
+
+    function toggleDescription() {
+      description.classList.toggle("hidden");
+      toggleBtn.classList.toggle("hidden");
+    }
+
+    function hideDescription() {
+      description.classList.add("hidden");
+      toggleBtn.classList.remove("hidden");
+    }
+  }
+</script>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -2,12 +2,35 @@
   <div class="flex flex-col md:flex-row items-end">
     <div class="w-full md:w-3/4 h-96 md:h-screen relative">
       <% if @architecture.images.any? %>
-        <%= image_tag @architecture.images.sample.url, class: 'absolute inset-0 object-cover object-top h-full w-full' %>
+        <%= image_tag @architecture.images.first.url, class: 'image absolute inset-0 object-cover object-top h-full w-full' %>
       <% else %>
         <%= image_tag 'architecture_placeholder.png', class: 'absolute inset-0 object-cover object-top h-full w-full' %>
       <% end %>
+      <div class="progress-bar h-1 bg-second absolute top-0 left-0 ease-in-out duration-300"></div>
+      <div class="description hidden absolute inset-0 bg-black bg-opacity-50 text-white p-4 tracking-widest">
+        <button class="close-btn absolute top-2 right-2 p-2 text-xl text-white">
+          <span class="fa-stack hover:scale-110">
+            <i class="fas fa-circle fa-stack-2x text-white fa-stack-2x"></i>
+            <i class="fa-solid fa-xmark text-theme text-2xl fa-stack-1x pt-1"></i>
+          </span>
+        </button>
+        <div class="flex flex-col justify-center items-center h-full">
+          <div class="max-w-2xl sm:mt-12 mt-6">
+            <p><%= safe_join(@architecture.description.split("\n"), tag(:br)) %></p>
+            <br>
+            <% if @architecture.architect.present? %>
+              <p><%= Architecture.human_attribute_name(:architect) %> : <%= @architecture.architect %></p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+      <button class="toggle-btn absolute top-0 right-0 p-4 text-xl">
+        <span class="fa-stack hover:scale-110">
+          <i class="fas fa-circle fa-stack-2x text-white fa-stack-2x"></i>
+          <i class="fa-solid fa-book-open-reader text-theme text-2xl fa-stack-1x pt-1"></i>
+        </span>
+      </button>
     </div>
-    
     <div class="w-full md:w-144 px-4 md:pt-0 pt-4">
       <h1 class="text-3xl md:text-5xl mb-4"><%= @architecture.name %></h1>
       <div class="relative my-8 mb-20">
@@ -17,8 +40,16 @@
           <p class="px-2">距離 28km</p>
         </div>
         <div class="pt-4">
-          <%= button_to 'Like', likes_path(architecture_id: @architecture.id), method: :post, class: 'w-full bg-second text-black mb-4 rounded-full hover:scale-105 hover:drop-shadow-lg' %>
-          <%= button_to 'Reload', root_path, method: :get, class: 'w-full bg-black text-white rounded-full mt-4 hover:scale-105 hover:drop-shadow-lg' %>
+          <% if @architecture.by?(current_user) %>
+            <%= button_to 'Edit', edit_architecture_path(@architecture), method: :get, class: 'w-full bg-sixth text-black mb-4 rounded-full hover:scale-105 hover:drop-shadow-lg' %>
+            <%= button_to 'Destroy', architecture_path(@architecture), method: :delete, data: { confirm: t('defaults.message.destroy_confirm') }, class: 'w-full bg-seventh text-white rounded-full mt-4 hover:scale-105 hover:drop-shadow-lg' %>
+          <% elsif current_user.like?(@architecture) %>
+            <%= button_to 'Check in', new_architecture_path, method: :get, class: 'w-full bg-second text-black mb-4 rounded-full hover:scale-105 hover:drop-shadow-lg' %>
+            <%= button_to 'Not Like', like_path, method: :delete, class: 'w-full bg-seventh text-white rounded-full mt-4 hover:scale-105 hover:drop-shadow-lg' %>
+          <% else %>
+            <%= button_to 'Like', likes_path(architecture_id: @architecture.id), method: :post, class: 'w-full bg-second text-black mb-4 rounded-full hover:scale-105 hover:drop-shadow-lg' %>
+            <%= button_to 'Reload', root_path, method: :get, class: 'w-full bg-black text-white rounded-full mt-4 hover:scale-105 hover:drop-shadow-lg' %>
+          <% end %>
         </div>
       </div>
     </div>
@@ -26,3 +57,55 @@
 <% else %>
   <p><%= t('.no_result') %></p>
 <% end %>
+
+<script>
+  document.addEventListener("turbolinks:load", function() {
+    initializeArchitecture();
+  });
+
+  function initializeArchitecture() {
+    const images = <%= @architecture.images.to_json.html_safe %>;
+    const image = document.querySelector(".image");
+    const progressBar = document.querySelector(".progress-bar");
+    const toggleBtn = document.querySelector(".toggle-btn");
+    const description = document.querySelector(".description");
+    const closeBtn = document.querySelector(".close-btn");
+    let currentIndex = 0;
+
+    updateProgressBar();
+
+    image.addEventListener("click", function(event) {
+      const clickedX = event.clientX - event.target.getBoundingClientRect().left;
+      const halfWidth = event.target.clientWidth / 2;
+
+      if (clickedX >= halfWidth) {
+        currentIndex = (currentIndex + 1) % images.length;
+      } else {
+        currentIndex = (currentIndex - 1 + images.length) % images.length;
+      }
+
+      image.src = images[currentIndex].url;
+      updateProgressBar();
+      hideDescription();
+    });
+
+    toggleBtn.addEventListener("click", toggleDescription);
+
+    closeBtn.addEventListener("click", hideDescription);
+
+    function updateProgressBar() {
+      const progressBarWidth = (currentIndex + 1) * (100 / images.length);
+      progressBar.style.width = `${progressBarWidth}%`;
+    }
+
+    function toggleDescription() {
+      description.classList.toggle("hidden");
+      toggleBtn.classList.toggle("hidden");
+    }
+
+    function hideDescription() {
+      description.classList.add("hidden");
+      toggleBtn.classList.remove("hidden");
+    }
+  }
+</script>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -15,7 +15,7 @@ ja:
         location: '所在地'
         open_range: '公開範囲'
         architect: '設計者'
-        description: 'メモ'
+        description: 'ノート'
         images: '写真'
         created_at: '作成日時'
         updated_at: '更新日時'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -20,6 +20,7 @@ ja:
       deleted: "%{item}を削除しました"
       delete_confirm: '削除しますか？'
       logout_confirm: 'ログアウトしますか？'
+      destroy_confirm: '削除しますか？'
       user_delete_confirm: '退会しますか？'
   header:
     top: 'トップ'

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -14,7 +14,9 @@ module.exports = {
         second: "#f4e464",
         third: "#f3f4f6",
         fourth: "#b2b2b2",
-        fifth: "#0E3068"
+        fifth: "#0E3068",
+        sixth: "#A6F147",
+        seventh: "#C96040"
       },
       fontFamily: {
         open_sans: ["Open Sans", "sans-serif"],


### PR DESCRIPTION
## チェック項目
- [x] 他のユーザーが記録し、Likeしていない建築詳細ページでは、Like、Reloadボタンが表示されている
- [x] 他のユーザーが作成し、Like済みの建築詳細ページでは、Check in、Not Likeが表示される
- [x] 自分が記録した建築詳細ページでは、Edit、Destroyボタンが表示される

## 画面遷移
- [x] Not Lkeを押すとLike一覧画面に遷移する
- [x] Destroyを押すと訪れた建築一覧画面に遷移する
