### PR TITLE
fix: auth_paramsのpermitに:oauth_tokenと:oauth_verifierを追加

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -17,7 +17,7 @@ class OauthsController < ApplicationController
   private
 
   def auth_params
-    params.permit(:code, :provider, :denied)
+    params.permit(:code, :provider, :denied, :oauth_token, :oauth_verifier)
   end
 
   def create_user_from(provider)


### PR DESCRIPTION
本番環境でTwitterログイン画面に遷移できないため、oauthコントローラーのパラメーターでoauth_tokenとoauth_verifierを許可しました。