### PR TITLE
fix: セキュリティ、レイアウトの修正

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -39,11 +39,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   def failure
-    if request.referer.nil?
-      redirect_to root_path
-    else
-      redirect_to request.referer
-    end
+    redirect_to root_path
   end
 
   def update_passwords
@@ -55,7 +51,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   protected
-  
+
   def update_resource(resource, params)
     resource.update_without_password(params)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,11 @@ class User < ApplicationRecord
         :confirmable, :lockable, :timeoutable, :omniauthable, omniauth_providers: [:twitter]
   
   validates :name, presence: true, length: { maximum: 255 }, on: :create
+  validate :password_complexity
+  def password_complexity
+    return if password.blank? || password =~ /(?=.*?[0-9])/
+    errors.add :password, "は数字と英字を混ぜたものを入力してください"
+  end
   has_many :architecture, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :like_architecture, through: :likes, source: :architecture

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }, on: :create
   validate :password_complexity
   def password_complexity
-    return if password.blank? || password =~ /(?=.*?[0-9])/
+    return if password.blank? || password =~ /(?=.*?[a-z])(?=.*?[0-9])/
     errors.add :password, "は数字と英字を混ぜたものを入力してください"
   end
   has_many :architecture, dependent: :destroy

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,9 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= @email %> さま</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p>以下のURLをクリックして、会員登録を完了してください。
+<br>うまくリンク先に移動しない場合は、URLをコピーしてブラウザのアドレスバーにペーストして下さい。
+</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to nil, confirmation_url(@resource, confirmation_token: @token) %></p>
+
+<p>引き続き、ご愛顧のほどよろしくお願い申し上げます。</p>

--- a/app/views/diagnosis/new.html.erb
+++ b/app/views/diagnosis/new.html.erb
@@ -4,7 +4,7 @@
       <div class="relative flex flex-col md:flex-row items-end">
         <div class="w-full md:w-3/4 h-screen relative">
           <%= image_tag q[:image], class: 'image absolute object-cover h-full w-full' %>
-          <div class="absolute inset-0 bg-first bg-opacity-50 text-white tracking-widest">
+          <div class="absolute inset-0 bg-black bg-opacity-50 text-white tracking-widest">
             <p class="text-center w-full bg-first text-white">あなたについて教えてください</p>
             <div class="flex flex-col justify-center items-center h-full">
               <div class="max-w-2xl text-center pb-24">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -17,11 +17,11 @@
     <table class="w-full ">
       <tr class="flex mb-12 justify-between">
         <th class="w-1/2 text-start"><%= t(User.human_attribute_name(:name)) %></th>
-        <td class="w-1/2 text-end"><%= current_user.name %></td>
+        <td class="w-1/2 text-end break-words"><%= current_user.name %></td>
       </tr>
       <tr class="flex mb-12 justify-between">
         <th class="w-1/2 text-start"><%= t(User.human_attribute_name(:email)) %></th>
-        <td class="w-1/2 text-end"><%= current_user.email %></td>
+        <td class="w-1/2 text-end break-words"><%= current_user.email %></td>
       </tr>
     </table>
   </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -90,7 +90,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
@@ -188,7 +188,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 3.days
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.
@@ -208,7 +208,7 @@ Devise.setup do |config|
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 10
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
   # config.unlock_in = 1.hour

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -49,7 +49,7 @@ ja:
         action: メールアドレスの確認
         greeting: "%{recipient}様"
         instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
-        subject: メールアドレス確認メール
+        subject: ようこそarchimateへ
       email_changed:
         greeting: こんにちは、%{recipient}様。
         message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。


### PR DESCRIPTION
## チェック項目
### セキュリティ関連
- [x] パスワードは8文字以上、英数字を組み合わせたものに制限されている
- [x] セッション有効期限が3日間に設定されている
- [x] パスワードリセット画面で存在しないアドレスは入力された場合も存在しないことがわからないようなメッセージが表示される
- [x] 10回パスワードを間違えるとアカウントがロックされ、アカウントロック解除のメールが送信される。メールのリンクからアカウントロックを解除できる

### その他
- [x] メールアドレス確認メールのリンクがうまく動作しなかった場合でも、コピーできるようにURLがメール文面に記載されている
- [x] 新規会員登録でバリデーションエラーが起こった際にリロードするとトップページに遷移する