### PR TITLE
feat: アクティブストレージのカスタムバリデータを追加

### DIFF
--- a/app/controllers/architecture_controller.rb
+++ b/app/controllers/architecture_controller.rb
@@ -12,20 +12,27 @@ class ArchitectureController < ApplicationController
 
   def create
     @architecture = current_user.architecture.build(architecture_params)
-    if params[:architecture][:new_images].present?
-      @architecture.images.attach(params[:architecture][:new_images])
+    new_images = params[:architecture][:new_images]
+    if new_images.present?
+      resize_image
+      @architecture.images.attach(new_images)
     end
-    if @architecture.save
-      redirect_to architecture_index_path, notice: t('defaults.message.created', item: Architecture.model_name.human)
+    if @architecture.errors.empty?
+      if @architecture.save
+        redirect_to architecture_index_path, notice: t('defaults.message.created', item: Architecture.model_name.human)
+      else
+        flash.now['notice'] = t('defaults.message.not_created', item: Architecture.model_name.human)
+        render :new
+      end
     else
-      flash.now['notice'] = t('defaults.message.not_created', item: Architecture.model_name.human)
-      render :new
+      flash.now['notice'] = @architecture.errors.full_messages.first
+      render :edit
     end
   end
 
   def show
     @architecture = Architecture.find(params[:id])
-    @images = @architecture.images.map { |image| rails_representation_path(image.variant(resize:'2048x2048').processed) }.to_json.html_safe
+    @images = @architecture.images.map { |image| rails_blob_path(image) }.to_json.html_safe
   end
 
   def edit
@@ -38,12 +45,17 @@ class ArchitectureController < ApplicationController
     new_images = params[:architecture][:new_images]
     
     if existing_images.present? || new_images.present?
-      @architecture.images.where.not(id: existing_images).purge
+      @architecture.images.transaction do
+        resize_image if new_images.present?
+        raise ActiveRecord::Rollback if @architecture.errors.any?
+        @architecture.images.where.not(id: existing_images).purge
+      end
     else
       @architecture.errors.add(:images, '写真が一枚も選択されていません')
     end
   
     if new_images.present?
+      resize_image
       @architecture.images.attach(new_images)
     end
       
@@ -70,5 +82,16 @@ class ArchitectureController < ApplicationController
 
   def architecture_params
     params.require(:architecture).permit(:name, :location, :architect, :description, :open_range, :experience, images: [], tag_ids: [])
+  end
+
+  def resize_image
+    new_images = params[:architecture][:new_images]
+    new_images.each do |image|
+      if image.content_type.start_with?('image/jpeg' || 'image/png')
+        image.tempfile = ImageProcessing::MiniMagick.source(image.tempfile).resize_to_fit(1920, 1920).call
+      else
+        @architecture.errors.add(:images, 'は不正なファイル形式です')
+      end
+    end
   end
 end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -3,7 +3,7 @@ class LikesController < ApplicationController
 
   def index
     @q = current_user.like_architecture.ransack(params[:q])
-    @like_architecture = @q.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page])
+    @like_architecture = @q.result(distinct: true).order(created_at: :desc).page(params[:page])
   end
 
   def create

--- a/app/models/architecture.rb
+++ b/app/models/architecture.rb
@@ -12,7 +12,7 @@ class Architecture < ApplicationRecord
   validates :images, attached_file_presence: true
   validates :images, attached_file_number: { maximum: 10 }
   validates :images, attached_file_size: { maximum: 5.megabytes }
-  validates :images, attached_file_type: { pattern: /^image\// }
+  validates :images, attached_file_type: { pattern: /^image\/(jpeg|png)$/ }
 
   enum open_range: { unpublish: 0, publish: 1 }
   enum experience: { possible: 0, impossible: 1 }

--- a/app/views/architecture/_architecture.html.erb
+++ b/app/views/architecture/_architecture.html.erb
@@ -1,6 +1,6 @@
 <div class="group relative flex h-80 items-end overflow-hidden rounded-md bg-gray-100 p-4 shadow-lg">
   <%= link_to architecture_path(architecture) do %>
-    <%= image_tag architecture.images.first, class: 'absolute inset-0 h-full w-full object-cover object-center transition duration-200 group-hover:scale-110'%>
+    <%= image_tag architecture.images.first.variant(resize:'1024x1024').processed, class: 'absolute inset-0 h-full w-full object-cover object-center transition duration-200 group-hover:scale-110'%>
   <% end %>
   <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-gray-900 via-transparent to-transparent opacity-50"></div>
 


### PR DESCRIPTION
## チェック項目
- [x] 建築記録時にjpeg、png以外の形式のファイルを入力するとバリデーションエラーが発生する
- [x] 建築情報編集時にバリデーションエラーが発生した場合、画像に関する処理が中断されDBの値が変更されない