### PR TITLE
fix: マッチング結果画面のボタンの位置を修正

### DIFF
--- a/app/views/diagnosis/index.html.erb
+++ b/app/views/diagnosis/index.html.erb
@@ -22,24 +22,24 @@
       <div class="relative my-8 mb-20">
         <p><%= simple_format(architecture.location) %></p>
         <div class="md:static bottom-5 w-full text-white">
-          <div class="flex flex-row-reverse md:flex-col my-8 mb-20 text-center justify-between items-center">
+          <div class="flex flex-row-reverse md:flex-col my-8 mb-20 text-center justify-center items-center">
             <% if logged_in? %>
               <%= render 'shared/like_nope_button', architecture: architecture %>
-              <%= link_to new_architecture_path, method: :get, class: 'bg-third md:bg-first border border-first text-first md:text-white h-16 w-16 leading-16 md:leading-normal md:w-full md:h-fit ml-20 md:ml-0 rounded-full hover:scale-105 hover:drop-shadow-lg cursor-pointer md:flex md:justify-center md:items-center' do %>
-                <i class="fa-solid fa-check fa-2xl md:text-sm md:mr-2"></i>
+              <%= link_to new_architecture_path, method: :get, method: :get, class: 'flex items-center justify-center bg-third md:bg-sixth text-first h-14 w-14 border border-first md:border-none md:h-fit md:w-full md:mb-8 mx-6 rounded-full hover:scale-105 hover:drop-shadow-lg cursor-pointer' do %>
+                <i class="fa-solid fa-check fa-xl md:text-sm md:mr-2"></i>
                 <div class="hidden md:block">
                   <p>Check in</p>
                 </div>
               <% end %>
             <% else %>
-              <div id="modalOpen" class="bg-third border border-seventh text-seventh h-16 w-16 leading-16 md:leading-normal md:h-fit md:w-full md:mb-8 mr-20 md:mr-0 rounded-full hover:scale-105 hover:drop-shadow-lg cursor-pointer md:flex md:justify-center md:items-center">
-                <i class="fa-regular fa-heart fa-2xl md:text-sm md:mr-2"></i>
+              <div id="modalOpen" class="flex items-center justify-center bg-third border border-seventh text-seventh h-14 w-14 md:h-fit mx-6 md:w-full md:mb-8 rounded-full hover:scale-105 hover:drop-shadow-lg cursor-pointer">
+                <i class="fa-regular fa-heart fa-xl md:text-sm md:mr-2"></i>
                 <div class="hidden md:block">
                   <p>Like</p>
                 </div>
               </div>
-              <div id="modalOpen" class="bg-third md:bg-first border border-first text-first md:text-white h-16 w-16 leading-16 md:leading-normal md:w-full md:h-fit ml-20 md:ml-0 rounded-full hover:scale-105 hover:drop-shadow-lg cursor-pointer md:flex md:justify-center md:items-center">
-                <i class="fa-solid fa-check fa-2xl md:text-sm md:mr-2"></i>
+              <div id="modalOpen" class="flex items-center justify-center bg-third border border-first text-first h-14 w-14 md:h-fit mx-6 md:w-full md:mb-8 rounded-full hover:scale-105 hover:drop-shadow-lg cursor-pointer">
+                <i class="fa-solid fa-check fa-xl md:text-sm md:mr-2"></i>
                 <div class="hidden md:block">
                   <p>Check in</p>
                 </div>


### PR DESCRIPTION
マッチング結果画面のボタン配置が、justify-betweenになっていたため、justify-centerに修正し、marginを追加しました。