### PR TITLE
fix: 新規登録時のメールアドレス認証をオフ、パスワードの英数組み合わせ必須のバリデーションをオフに変更

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,14 +2,10 @@ class User < ApplicationRecord
   mount_uploader :avatar, AvatarUploader
   devise :database_authenticatable, :registerable,
         :recoverable, :rememberable, :trackable, :validatable,
-        :confirmable, :lockable, :timeoutable, :omniauthable, omniauth_providers: [:twitter]
+        :lockable, :timeoutable, :omniauthable, omniauth_providers: [:twitter]
   
   validates :name, presence: true, length: { maximum: 255 }, on: :create
-  validate :password_complexity
-  def password_complexity
-    return if password.blank? || password =~ /(?=.*?[a-z])(?=.*?[0-9])/
-    errors.add :password, "は数字と英字を混ぜたものを入力してください"
-  end
+  # validate :password_complexity
   has_many :architecture, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :like_architecture, through: :likes, source: :architecture
@@ -46,9 +42,14 @@ class User < ApplicationRecord
     like_architecture.include?(architecture)
   end
 
-    private
+  private
+  
+  def self.dummy_email(auth)
+    "#{auth.uid}-#{auth.provider}@example.com"
+  end
 
-    def self.dummy_email(auth)
-      "#{auth.uid}-#{auth.provider}@example.com"
-    end
+  def password_complexity
+    return if password.blank? || password =~ /(?=.*?[a-z])(?=.*?[0-9])/
+    errors.add :password, "は数字と英字を混ぜたものを入力してください"
+  end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 8..128
+  config.password_length = 4..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly


### PR DESCRIPTION
## チェック項目
- [x] 新規会員登録時に、メールアドレスの認証を経ずに即時ログインできる
- [x] パスワードは英数組み合わせでなくてもバリデーションに引っかからない
- [x] パスワードは４文字以上であればバリデーションに引っかからない

上記の変更を行いました。