### PR TITLE
fix: メールアドレス認証スキップに伴い、Twitter認証のskip_confirmation!メソッドの記載を削除

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,6 @@ class User < ApplicationRecord
         password: Devise.friendly_token[0, 20]
       )
     end
-    user.skip_confirmation!
     user
   end
 


### PR DESCRIPTION
メールアドレス認証スキップに伴い、Twitter認証のskip_confirmation!メソッドの記載を削除しました。
## チェック項目
- [x] Twitterで会員登録、ログインができる