### PR TITLE
fix: 建築画像の両端にヒントを追加

### DIFF
--- a/app/controllers/diagnosis_controller.rb
+++ b/app/controllers/diagnosis_controller.rb
@@ -31,7 +31,7 @@ class DiagnosisController < ApplicationController
     session_key = "architecture_order"
   
     if session[session_key].nil?
-      others_architecture = Architecture.where.not(user_id: current_user&.id).where(experience: 0).to_a.shuffle
+      others_architecture = Architecture.where(experience: 0).to_a.shuffle
       session[session_key] = others_architecture.map(&:id)
     else
       shuffled_ids = session[session_key]

--- a/app/javascript/javascripts/shared/diagnosis_progress_bar.js
+++ b/app/javascript/javascripts/shared/diagnosis_progress_bar.js
@@ -10,14 +10,33 @@ const initializeArchitecture = () => {
     const architectureImages = JSON.parse(imagesInput.value);
     const image = container.querySelector('.image');
     const progressBar = container.querySelector('.progress-bar');
+    const arrowLeft = container.querySelector('.fa-chevron-left');
+    const arrowRight = container.querySelector('.fa-chevron-right');
     let currentIndex = 0;
 
     const updateProgressBar = () => {
       const progressBarWidth = (currentIndex + 1) * (100 / architectureImages.length);
       progressBar.style.width = `${progressBarWidth}%`;
-    }
-    
+    };
+
+    const updateImage = () => {
+      image.src = architectureImages[currentIndex];
+    };
+
     updateProgressBar();
+    updateImage();
+
+    arrowLeft.addEventListener('click', () => {
+      currentIndex = (currentIndex - 1 + architectureImages.length) % architectureImages.length;
+      updateImage();
+      updateProgressBar();
+    });
+
+    arrowRight.addEventListener('click', () => {
+      currentIndex = (currentIndex + 1) % architectureImages.length;
+      updateImage();
+      updateProgressBar();
+    });
 
     image.addEventListener('click', (event) => {
       const clickedX = event.clientX - event.target.getBoundingClientRect().left;
@@ -28,10 +47,11 @@ const initializeArchitecture = () => {
       } else {
         currentIndex = (currentIndex - 1 + architectureImages.length) % architectureImages.length;
       }
+
       if (architectureImages.length >= 2) {
-        image.src = architectureImages[currentIndex];
-      }  
-      updateProgressBar();
+        updateImage();
+        updateProgressBar();
+      }
     });
   });
 };

--- a/app/javascript/javascripts/shared/progress_bar.js
+++ b/app/javascript/javascripts/shared/progress_bar.js
@@ -7,16 +7,36 @@ const initializeArchitecture = () => {
   let architectureImages = JSON.parse(images);
   const image = document.querySelector(".image");
   const progressBar = document.querySelector(".progress-bar");
+  const arrowLeft = document.querySelector(".fa-chevron-left");
+  const arrowRight = document.querySelector(".fa-chevron-right");
   let currentIndex = 0;
 
   const updateProgressBar = () => {
     const progressBarWidth = (currentIndex + 1) * (100 / architectureImages.length);
     progressBar.style.width = `${progressBarWidth}%`;
-  }
+  };
+
+  const updateImage = () => {
+    image.src = architectureImages[currentIndex];
+  };
 
   updateProgressBar();
+  updateImage();
 
-  image.addEventListener("click", (event) => {
+  arrowLeft.addEventListener("click", () => {
+    currentIndex = (currentIndex - 1 + architectureImages.length) % architectureImages.length;
+    updateImage();
+    updateProgressBar();
+  });
+
+  arrowRight.addEventListener("click", () => {
+    currentIndex = (currentIndex + 1) % architectureImages.length;
+    updateImage();
+    updateProgressBar();
+  });
+
+  // Add the event listener to the image for click on the left or right half of the image
+  image.addEventListener('click', (event) => {
     const clickedX = event.clientX - event.target.getBoundingClientRect().left;
     const halfWidth = event.target.clientWidth / 2;
 
@@ -25,9 +45,8 @@ const initializeArchitecture = () => {
     } else {
       currentIndex = (currentIndex - 1 + architectureImages.length) % architectureImages.length;
     }
-    if (architectureImages.length >= 2) {
-      image.src = architectureImages[currentIndex];
-    }
+
+    updateImage();
     updateProgressBar();
   });
-}
+};

--- a/app/views/diagnosis/index.html.erb
+++ b/app/views/diagnosis/index.html.erb
@@ -31,12 +31,27 @@
         <div class="md:static bottom-5 w-full text-white">
           <div class="flex flex-row-reverse md:flex-col my-8 mb-20 text-center justify-center items-center">
             <% if user_signed_in? %>
-              <%= render 'shared/like_nope_button', architecture: architecture %>
-              <%= link_to check_in_architecture_index_path(name: architecture.name, pref: architecture.pref, location: architecture.location, open_range: architecture.open_range, experience: architecture.experience, architect: architecture.architect), method: :get, method: :get, class: 'flex items-center justify-center bg-third border border-first text-first h-14 w-14 md:h-fit mx-6 md:w-full rounded-full hover:scale-105 hover:drop-shadow-lg cursor-pointer' do %>
-                <i class="fa-solid fa-check fa-xl md:text-sm md:mr-2"></i>
-                <div class="hidden md:block">
-                  <p>Check in</p>
-                </div>
+              <% if architecture.by?(current_user) %>
+                <%= link_to edit_architecture_path(architecture), method: :get, class: 'flex items-center justify-center bg-third border border-first text-first h-14 w-14 md:h-fit md:w-full md:mb-8 mx-6 rounded-full hover:scale-105 hover:drop-shadow-lg cursor-pointer' do %>
+                  <i class="fa-regular fa-pen-to-square fa-xl md:text-sm md:mr-2"></i>
+                  <div class="hidden md:block">
+                    <p>Edit</p>
+                  </div>
+                <% end %>
+                <%= link_to architecture_path(architecture), method: :delete, data: { confirm: t('defaults.message.destroy_confirm') }, class: 'flex items-center justify-center bg-seventh border border-seventh h-14 w-14 md:w-full mx-6 md:h-fit rounded-full hover:scale-105 hover:drop-shadow-lg cursor-pointer' do %>
+                  <i class="fa-regular fa-trash-can fa-xl md:text-sm md:mr-2"></i>
+                  <div class="hidden md:block">
+                    <p>Delete</p>
+                  </div>
+                <% end %>
+              <% else %>
+                <%= render 'shared/like_nope_button', architecture: architecture %>
+                <%= link_to check_in_architecture_index_path(name: architecture.name, pref: architecture.pref, location: architecture.location, open_range: architecture.open_range, experience: architecture.experience, architect: architecture.architect), method: :get, method: :get, class: 'flex items-center justify-center bg-third border border-first text-first h-14 w-14 md:h-fit mx-6 md:w-full rounded-full hover:scale-105 hover:drop-shadow-lg cursor-pointer' do %>
+                  <i class="fa-solid fa-check fa-xl md:text-sm md:mr-2"></i>
+                  <div class="hidden md:block">
+                    <p>Check in</p>
+                  </div>
+                <% end %>
               <% end %>
             <% else %>
               <div id="modalOpen" class="flex items-center justify-center bg-third border border-seventh text-seventh h-14 w-14 md:h-fit mx-6 md:w-full md:mb-8 rounded-full hover:scale-105 hover:drop-shadow-lg cursor-pointer">

--- a/app/views/shared/_architecture.html.erb
+++ b/app/views/shared/_architecture.html.erb
@@ -2,8 +2,10 @@
 
 <% if controller.controller_name == "static_pages" %>
   <%= image_tag architecture.images.first, class: 'image absolute object-cover object-top h-full w-full animate-scale-in-hor-left' %>
+  <%= render 'shared/arrow' %>
 <% else %>
   <%= image_tag architecture.images.first, class: 'image absolute object-cover object-top h-full w-full' %>
+  <%= render 'shared/arrow' %>
 <% end %>
 <div class="progress-bar h-1 bg-second absolute top-0 left-0 ease-in-out duration-300"></div>
 <div class="description hidden absolute inset-0 bg-black bg-opacity-50 text-white">

--- a/app/views/shared/_arrow.html.erb
+++ b/app/views/shared/_arrow.html.erb
@@ -1,0 +1,6 @@
+<div class="absolute top-0 left-0 h-full ml-2 flex items-center justify-center">
+  <i class="fa-solid fa-chevron-left text-white text-4xl opacity-50 cursor-pointer"></i>
+</div>
+<div class="absolute top-0 right-0 h-full mr-2 flex items-center justify-center">
+  <i class="fa-solid fa-chevron-right text-white text-4xl opacity-50 cursor-pointer"></i>
+</div>


### PR DESCRIPTION
## チェク項目
- [x] 建築画像の両端に、次の画像や前の画像があることを知らせるアイコンが表示されている
- [x] 自分が記録した建築にもマッチングする