### PR TITLE
fix: gem fakerを本番環境でも使えるように修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,13 +46,13 @@ gem 'image_processing'
 gem 'fog-aws'
 gem 'mapbox-sdk'
 gem 'mapbox-gl-rails'
+gem 'faker'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
   gem 'factory_bot_rails'
-  gem 'faker'
   gem 'shoulda-matchers'
 end
 


### PR DESCRIPTION
Herokuへのデプロイ中にエラーが発生したため、Gemfile内gem 'faker'の記述を本番環境へ移動しました。