### PR TITLE
chore: config.cache_classesをfalseに変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,7 +4,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers


### PR DESCRIPTION
EC2上でrails db:createコマンドを実行しようとした際に、Springがリロードを要求したため、config.cache_classesをfalseに変更しました。