### PR TITLE
feat: 建築検索フォームのタグボタンを開閉式に変更

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -22,6 +22,7 @@ import "./diagnosis/diagnosis_progress_bar";
 import "./architecture/preview";
 import "./architecture/keep_search_params";
 import "./architecture/tag";
+import "./architecture/tag_open";
 import "./architecture/search_range";
 import "./registrations/edit";
 import "./users/show";

--- a/app/javascript/packs/architecture/tag_open.js
+++ b/app/javascript/packs/architecture/tag_open.js
@@ -1,0 +1,55 @@
+document.addEventListener('turbolinks:load', () => {
+  const saveTagListState = () => {
+    const tagList = document.querySelector('.tag-list');
+    const isHidden = tagList.classList.contains('hidden');
+    
+    document.cookie = `tagListHidden=${isHidden ? '1' : '0'}; expires=Thu, 01 Jan 2030 00:00:00 UTC; path=/`;
+  }
+
+  const restoreTagListState = () => {
+    const tagList = document.querySelector('.tag-list');
+    const tagListHidden = getCookie('tagListHidden');
+    const openIcon = document.querySelector('#open-icon');
+    const closeIcon = document.querySelector('#close-icon');
+
+    if (tagListHidden === '1') {
+      tagList.classList.add('hidden');
+      openIcon.classList.remove('hidden');
+      closeIcon.classList.add('hidden');
+    } else {
+      tagList.classList.remove('hidden');
+      openIcon.classList.add('hidden');
+      closeIcon.classList.remove('hidden');
+    }
+  }
+
+  const getCookie = (name) => {
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; ${name}=`);
+    if (parts.length === 2) {
+      return parts.pop().split(';').shift();
+    }
+    return null;
+  }
+
+  const toggleTagList = () => {
+    const tagList = document.querySelector('.tag-list');
+    const openIcon = document.querySelector('#open-icon');
+    const closeIcon = document.querySelector('#close-icon');
+
+    tagList.classList.toggle('hidden');
+    openIcon.classList.toggle('hidden');
+    closeIcon.classList.toggle('hidden');
+    saveTagListState();
+  }
+
+  const openButton = document.querySelector('#open-button');
+  openButton.addEventListener('click', toggleTagList);
+
+  const form = document.querySelector('#search-form');
+  form.addEventListener('submit', () => {
+    saveTagListState();
+  });
+
+  restoreTagListState();
+});

--- a/app/views/architecture/_search_form.html.erb
+++ b/app/views/architecture/_search_form.html.erb
@@ -1,6 +1,6 @@
 <div class="result-container relative">
   <%= form_with url: url, method: :get, id: 'search-form' do |f| %>
-    <div class="flex flex-col justify-center pb-12 sm:pb-16 lg:pb-20 text-xs">
+    <div class="flex flex-col justify-center pb-6 sm:pb-12 lg:pb-14 text-xs">
       <form class="flex">
         <div class="flex flex-col md:flex-row">
           <div class="w-full mb-6 md:mr-6">
@@ -19,32 +19,41 @@
         <div class="flex flex-wrap justify-center">
           <label class="flex items-center mb-6">
             <%= f.radio_button :category, "visited_architecture", id: "visited-radio", class: "form-radio hidden" %>
-            <a type="button" class="radio-button px-4 py-2 border-b border-gray-400 text-gray-400 cursor-pointer" id="visited-label">
+            <a type="button" class="radio-button px-2 md:px-4 py-2 border-b border-gray-400 text-gray-400 cursor-pointer" id="visited-label">
               <%= t('architecture.index.Visited Architecture') %>
             </a>
           </label>
           <label class="flex items-center mb-6">
             <%= f.radio_button :category, "others_architecture", id: "others-radio", class: "form-radio hidden" %>
-            <a type="button" class="radio-button px-4 py-2 border-b border-gray-400 text-gray-400 cursor-pointer" id="others-label">
+            <a type="button" class="radio-button px-2 md:px-4 py-2 border-b border-gray-400 text-gray-400 cursor-pointer" id="others-label">
               <%= t('architecture.index.Others Architecture') %>
             </a>
           </label>
           <label class="flex items-center mb-6">
             <%= f.radio_button :category, "liked_architecture", id: "liked-radio", class: "form-radio hidden" %>
-            <a type="button" class="radio-button px-4 py-2 border-b border-gray-400 text-gray-400 cursor-pointer" id="liked-label">
+            <a type="button" class="radio-button px-2 md:px-4 py-2 border-b border-gray-400 text-gray-400 cursor-pointer" id="liked-label">
               <%= t('architecture.index.Liked Architecture') %>
             </a>
           </label>
         </div>
-        <div class="flex flex-wrap">
-          <% Tag.all.each do |tag| %>
-            <label class="flex items-center mr-2 mb-2 md:mb-3">
-              <input type="checkbox" name="tag_ids[]" value="<%= tag.id %>" class="tag-button form-checkbox hidden">
-              <button type="button" class="tag-button px-2 py-1 rounded-full border border-gray-300 text-gray-600">
-                <a># <%= tag.name %></a>
-              </button>
-            </label>
-          <% end %>
+        <div id="open-button" class="flex justify-center mb-6">
+          <button type="button" class="tag-button px-2 py-1 rounded-full border border-gray-300 text-gray-600">
+            # タグを追加
+            <i id="open-icon" class="fa-solid fa-chevron-down ml-1"></i>
+            <i id="close-icon" class="fa-solid fa-chevron-up ml-1 hidden"></i>
+          </button>
+        </div>
+        <div class="tag-list hidden">
+          <div class="flex flex-wrap">
+            <% Tag.all.each do |tag| %>
+              <label class="flex items-center mr-2 mb-2 md:mb-3">
+                <input type="checkbox" name="tag_ids[]" value="<%= tag.id %>" class="tag-button form-checkbox hidden">
+                <button type="button" class="tag-button px-2 py-1 rounded-full border border-gray-300 text-gray-600">
+                  <a># <%= tag.name %></a>
+                </button>
+              </label>
+            <% end %>
+          </div>
         </div>
       </form>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,6 @@ Rails.application.routes.draw do
     get 'registrations/update_password', to: 'users/registrations#failure'
   end
 
-  get 'welcome', to: 'static_pages#welcome'
   get 'terms', to: 'static_pages#terms'
   get 'privacy_policy', to: 'static_pages#privacy_policy'
   get 'users_architecture', to: 'json_data#users_architecture'

--- a/lib/custom_authentication_failure.rb
+++ b/lib/custom_authentication_failure.rb
@@ -2,6 +2,6 @@ class CustomAuthenticationFailure < Devise::FailureApp
   protected
 
   def redirect_url
-    welcome_path
+    root_path
   end
 end


### PR DESCRIPTION
## チェック項目
- [x] 建築検索フォームのタグボタンの開閉が動作する
- [x] ページ遷移した際にもタグの開閉状態を維持する
- [x] タグの開閉に合わせてボタンのアイコンも変化する